### PR TITLE
Fix jest error "Cannot use import statement outside module" for axios

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -15,5 +15,6 @@ export default {
   testEnvironment: 'jsdom',
   moduleNameMapper: {
     '.*/markdown-content': '<rootDir>/src/components/common/__mocks__/markdown-content.tsx',
+    'axios': 'axios/dist/node/axios.cjs'
   },
 };


### PR DESCRIPTION
This will fix following error ocurring on jest for axios 1.3.4 and build will work

```
FAIL  src/api/linkedin-practices.spec.ts
  ● Test suite failed to run

    Jest encountered an unexpected token

    Jest failed to parse a file. This happens e.g. when your code or its dependencies use non-standard JavaScript syntax, or when Jest is not configured to support such syntax.

    Out of the box Jest supports Babel, which will be used to transform your files into valid JS based on your Babel configuration.

    By default "node_modules" folder is ignored by transformers.

    Here's what you can do:
     • If you are trying to use ECMAScript Modules, see https://jestjs.io/docs/ecmascript-modules for how to enable it.
     • If you are trying to use TypeScript, see https://jestjs.io/docs/getting-started#using-typescript
     • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
     • If you need a custom transformation specify a "transform" option in your config.
     • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.

    You'll find more details and examples of these config options in the docs:
    https://jestjs.io/docs/configuration
    For information about custom transformations, see:
    https://jestjs.io/docs/code-transformation

    Details:

    /home/janjitsu/projects/md2practice/node_modules/axios/index.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){import axios from './lib/axios.js';
                                                                                      ^^^^^^

    SyntaxError: Cannot use import statement outside a module

    > 1 | import axios from 'axios';
        | ^
      2 | import { marked } from 'marked';
      3 |
      4 | export interface LinkedInPracticeInfo {

      at Runtime.createScriptFromCode (node_modules/jest-runtime/build/index.js:1728:14)
      at Object.<anonymous> (src/api/linkedin-practices.ts:1:1)

```


see more about solution: https://stackoverflow.com/a/74297004