### PR TITLE
Fix new jest version requiring use latest node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [17.x]
+        node-version: [19.x]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Updates node version used by CI will fix the following error

```
yarn install v1.22.19                                                                                                                                                                                                                                                             
warning package-lock.json found. Your project contains lock files generated by tools other than Yarn. It is advised not to mix package managers in order to avoid resolution inconsistencies caused by unsynchronized lock files. To clear this warning, remove package-lock.json.
[1/4] Resolving packages...                                                                                                                                                                                                                                                       
[2/4] Fetching packages...                                                                                                                                                                                                                                                        
error babel-jest@29.4.3: The engine "node" is incompatible with this module. Expected version "^14.15.0 || ^16.10.0 || >=18.0.0". Got "17.3.0"                                                                                                                                    
error Found incompatible module.                                                                                                                                                                                                                                                  
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.     
```